### PR TITLE
🇵🇱 Init Polish translation

### DIFF
--- a/src/main/resources/assets/pquality/lang/pl_pl.json
+++ b/src/main/resources/assets/pquality/lang/pl_pl.json
@@ -1,0 +1,15 @@
+{
+    "contaminant.pquality.bronze_quality": "Brązowa jakość",
+    "contaminant.pquality.bronze_quality.absent": "Brak Brązowej jakości",
+    "contaminant.pquality.silver_quality": "Srebrna jakość",
+    "contaminant.pquality.silver_quality.absent": "Brak Srebrnej jakości",
+    "contaminant.pquality.gold_quality": "Złota jakość",
+    "contaminant.pquality.gold_quality.absent": "Brak Złotej jakości",
+    "contaminant.pquality.diamond_quality": "Diamentowa jakość",
+    "contaminant.pquality.diamond_quality.absent": "Brak Diamentowej jakości",
+    "contaminant.pquality.netherite_quality": "Netherytowa jakość",
+    "contaminant.pquality.netherite_quality.absent": "Brak Netherytowej jakości",
+
+    "enchantment.pquality.enhancement": "Ulepszanie",
+    "enchantment.pquality.enhancement.description": "Dodaje szanse na zwiększenie jakości zdobytych przedmiotów, w zależności od Twojego poziomu XP."
+}


### PR DESCRIPTION
I'm really not happy with the translation of the "Enhancement" enchant, but I really don't have any other words. It doesn't sound "magical" or "cryptic" enough for an enchant, but also every other word for "Enhancement" is either out of context or is really far from the original word and is of no use here.
The `.absent` keys should be correct, as per the context "hint" I was given by petrolpark.